### PR TITLE
[Fix] UISearchController HideSearchScrolling (#16)

### DIFF
--- a/Weather_iPhone/Sources/Controller/MainViewController.swift
+++ b/Weather_iPhone/Sources/Controller/MainViewController.swift
@@ -128,6 +128,7 @@ class MainViewController: UIViewController {
         searchController.searchBar.placeholder = "도시 또는 공항 검색"
         searchController.obscuresBackgroundDuringPresentation = true
         self.navigationItem.searchController = searchController
+        self.navigationItem.hidesSearchBarWhenScrolling = false
         
         navigationItem.rightBarButtonItem = UIBarButtonItem(image: UIImage(systemName: "ellipsis.circle"), style: .plain, target: self, action: #selector(handleMenu))
     }
@@ -150,7 +151,7 @@ class MainViewController: UIViewController {
 
 extension MainViewController: UITableViewDelegate, UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return 2
+        return 10
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {


### PR DESCRIPTION
## PR 요약 🍎
 - UISearchController Hide Search Scrolling을 추가하여 UISearchController가 초기 화면에도 유지되게 변경 완료
</br>

### 구현 화면
<img width="230" alt="이슈해결" src="https://user-images.githubusercontent.com/53035245/171614144-f5f86e12-c2dd-4347-b786-dbbff0183e3b.png">